### PR TITLE
style: disable use_self lint

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,6 @@
     clippy::explicit_iter_loop,
     clippy::future_not_send,
     clippy::todo,
-    clippy::use_self,
     missing_copy_implementations,
     missing_debug_implementations,
     unused_crate_dependencies,


### PR DESCRIPTION
Fixes recently added lint by removing said lint 👋 

---

  * style: disable use_self lint (a2d7777)
        
        To avoid the recursive type name lint which would bump MSRV. I'm not
        sold on this lint anyway!
                  