### PR TITLE
Add second lifetime for the query in iterators.

### DIFF
--- a/src/iter/pruning_iter.rs
+++ b/src/iter/pruning_iter.rs
@@ -15,18 +15,18 @@ pub(crate) trait PruningOracle<R, V> {
 /// An [`Iterator`] that performs a depth-first, in-order walk of a subtree and
 /// yields [`Node`] instances that match a pruning predicate.
 #[derive(Debug)]
-pub(crate) struct PruningIter<'a, R, V, T> {
-    query: &'a Range<R>,
+pub(crate) struct PruningIter<'a, 'b, R, V, T> {
+    query: &'b Range<R>,
     stack: Vec<&'a Node<R, V>>,
     pruner: T,
 }
 
-impl<'a, R, V, T> PruningIter<'a, R, V, T>
+impl<'a, 'b, R, V, T> PruningIter<'a, 'b, R, V, T>
 where
     R: Ord,
     T: PruningOracle<R, V>,
 {
-    pub(crate) fn new(root: &'a Node<R, V>, query: &'a Range<R>, pruner: T) -> Self {
+    pub(crate) fn new(root: &'a Node<R, V>, query: &'b Range<R>, pruner: T) -> Self {
         let mut this = Self {
             stack: vec![],
             query,
@@ -50,7 +50,7 @@ where
     }
 }
 
-impl<'a, R, V, T> Iterator for PruningIter<'a, R, V, T>
+impl<'a, 'b, R, V, T> Iterator for PruningIter<'a, 'b, R, V, T>
 where
     R: Ord,
     T: PruningOracle<R, V>,

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -7,7 +7,7 @@ use crate::{
         ContainsPruner, DuringPruner, FinishesPruner, MeetsPruner, MetByPruner, OverlapsPruner,
         OwnedIter, PrecededByPruner, PrecedesPruner, PruningIter, RefIter, StartsPruner,
     },
-    node::{remove_recurse, Node, RemoveResult},
+    node::{Node, RemoveResult, remove_recurse},
 };
 
 /// An [`IntervalTree`] stores `(interval, value)` tuple mappings, enabling
@@ -161,10 +161,10 @@ where
     ///                                       Y
     /// ```
     ///
-    pub fn iter_overlaps<'a>(
+    pub fn iter_overlaps<'a: 'b, 'b>(
         &'a self,
-        range: &'a Range<R>,
-    ) -> impl Iterator<Item = (&'a Range<R>, &'a V)> {
+        range: &'b Range<R>,
+    ) -> impl Iterator<Item = (&'a Range<R>, &'a V)> + 'b {
         self.0
             .iter()
             .flat_map(|v| PruningIter::new(v, range, OverlapsPruner))
@@ -185,10 +185,10 @@ where
     ///                                            Y
     /// ```
     ///
-    pub fn iter_precedes<'a>(
+    pub fn iter_precedes<'a: 'b, 'b>(
         &'a self,
-        range: &'a Range<R>,
-    ) -> impl Iterator<Item = (&'a Range<R>, &'a V)> {
+        range: &'b Range<R>,
+    ) -> impl Iterator<Item = (&'a Range<R>, &'a V)> + 'b {
         self.0
             .iter()
             .flat_map(|v| PruningIter::new(v, range, PrecedesPruner))
@@ -209,10 +209,10 @@ where
     ///                        Y
     /// ```
     ///
-    pub fn iter_preceded_by<'a>(
+    pub fn iter_preceded_by<'a: 'b, 'b>(
         &'a self,
-        range: &'a Range<R>,
-    ) -> impl Iterator<Item = (&'a Range<R>, &'a V)> {
+        range: &'b Range<R>,
+    ) -> impl Iterator<Item = (&'a Range<R>, &'a V)> + 'b {
         self.0
             .iter()
             .flat_map(|v| PruningIter::new(v, range, PrecededByPruner))
@@ -233,10 +233,10 @@ where
     ///                                            Y
     /// ```
     ///
-    pub fn iter_meets<'a>(
+    pub fn iter_meets<'a: 'b, 'b>(
         &'a self,
-        range: &'a Range<R>,
-    ) -> impl Iterator<Item = (&'a Range<R>, &'a V)> {
+        range: &'b Range<R>,
+    ) -> impl Iterator<Item = (&'a Range<R>, &'a V)> + 'b {
         self.0
             .iter()
             .flat_map(|v| PruningIter::new(v, range, MeetsPruner))
@@ -257,10 +257,10 @@ where
     ///                           Y
     /// ```
     ///
-    pub fn iter_met_by<'a>(
+    pub fn iter_met_by<'a: 'b, 'b>(
         &'a self,
-        range: &'a Range<R>,
-    ) -> impl Iterator<Item = (&'a Range<R>, &'a V)> {
+        range: &'b Range<R>,
+    ) -> impl Iterator<Item = (&'a Range<R>, &'a V)> + 'b {
         self.0
             .iter()
             .flat_map(|v| PruningIter::new(v, range, MetByPruner))
@@ -281,10 +281,10 @@ where
     ///                                Y
     /// ```
     ///
-    pub fn iter_starts<'a>(
+    pub fn iter_starts<'a: 'b, 'b>(
         &'a self,
-        range: &'a Range<R>,
-    ) -> impl Iterator<Item = (&'a Range<R>, &'a V)> {
+        range: &'b Range<R>,
+    ) -> impl Iterator<Item = (&'a Range<R>, &'a V)> + 'b {
         self.0
             .iter()
             .flat_map(|v| PruningIter::new(v, range, StartsPruner))
@@ -305,10 +305,10 @@ where
     ///                                   Y
     /// ```
     ///
-    pub fn iter_finishes<'a>(
+    pub fn iter_finishes<'a: 'b, 'b>(
         &'a self,
-        range: &'a Range<R>,
-    ) -> impl Iterator<Item = (&'a Range<R>, &'a V)> {
+        range: &'b Range<R>,
+    ) -> impl Iterator<Item = (&'a Range<R>, &'a V)> + 'b {
         self.0
             .iter()
             .flat_map(|v| PruningIter::new(v, range, FinishesPruner))
@@ -329,10 +329,10 @@ where
     ///                                Y
     /// ```
     ///
-    pub fn iter_during<'a>(
+    pub fn iter_during<'a: 'b, 'b>(
         &'a self,
-        range: &'a Range<R>,
-    ) -> impl Iterator<Item = (&'a Range<R>, &'a V)> {
+        range: &'b Range<R>,
+    ) -> impl Iterator<Item = (&'a Range<R>, &'a V)> + 'b {
         self.0
             .iter()
             .flat_map(|v| PruningIter::new(v, range, DuringPruner))
@@ -353,10 +353,10 @@ where
     ///                                Y
     /// ```
     ///
-    pub fn iter_contains<'a>(
+    pub fn iter_contains<'a: 'b, 'b>(
         &'a self,
-        range: &'a Range<R>,
-    ) -> impl Iterator<Item = (&'a Range<R>, &'a V)> {
+        range: &'b Range<R>,
+    ) -> impl Iterator<Item = (&'a Range<R>, &'a V)> + 'b {
         self.0
             .iter()
             .flat_map(|v| PruningIter::new(v, range, ContainsPruner))
@@ -391,13 +391,13 @@ impl<R, V> std::iter::IntoIterator for IntervalTree<R, V> {
 mod tests {
     use std::{
         collections::{HashMap, HashSet},
-        sync::{atomic::AtomicUsize, Arc},
+        sync::{Arc, atomic::AtomicUsize},
     };
 
     use proptest::prelude::*;
 
     use super::*;
-    use crate::test_utils::{arbitrary_range, Lfsr, NodeFilterCount};
+    use crate::test_utils::{Lfsr, NodeFilterCount, arbitrary_range};
 
     #[test]
     fn test_insert_contains() {
@@ -828,17 +828,19 @@ mod tests {
 
             // Invariant 1: the left child always contains a value strictly
             // less than this node.
-            assert!(n
-                .left()
-                .map(|v| v.interval() < n.interval())
-                .unwrap_or(true));
+            assert!(
+                n.left()
+                    .map(|v| v.interval() < n.interval())
+                    .unwrap_or(true)
+            );
 
             // Invariant 2: the right child always contains a value striggctly
             // greater than this node.
-            assert!(n
-                .right()
-                .map(|v| v.interval() > n.interval())
-                .unwrap_or(true));
+            assert!(
+                n.right()
+                    .map(|v| v.interval() > n.interval())
+                    .unwrap_or(true)
+            );
 
             // Invariant 3: the height of this node is always +1 of the
             // maximum child height.

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -7,7 +7,7 @@ use crate::{
         ContainsPruner, DuringPruner, FinishesPruner, MeetsPruner, MetByPruner, OverlapsPruner,
         OwnedIter, PrecededByPruner, PrecedesPruner, PruningIter, RefIter, StartsPruner,
     },
-    node::{Node, RemoveResult, remove_recurse},
+    node::{remove_recurse, Node, RemoveResult},
 };
 
 /// An [`IntervalTree`] stores `(interval, value)` tuple mappings, enabling
@@ -391,13 +391,13 @@ impl<R, V> std::iter::IntoIterator for IntervalTree<R, V> {
 mod tests {
     use std::{
         collections::{HashMap, HashSet},
-        sync::{Arc, atomic::AtomicUsize},
+        sync::{atomic::AtomicUsize, Arc},
     };
 
     use proptest::prelude::*;
 
     use super::*;
-    use crate::test_utils::{Lfsr, NodeFilterCount, arbitrary_range};
+    use crate::test_utils::{arbitrary_range, Lfsr, NodeFilterCount};
 
     #[test]
     fn test_insert_contains() {
@@ -828,19 +828,17 @@ mod tests {
 
             // Invariant 1: the left child always contains a value strictly
             // less than this node.
-            assert!(
-                n.left()
-                    .map(|v| v.interval() < n.interval())
-                    .unwrap_or(true)
-            );
+            assert!(n
+                .left()
+                .map(|v| v.interval() < n.interval())
+                .unwrap_or(true));
 
             // Invariant 2: the right child always contains a value striggctly
             // greater than this node.
-            assert!(
-                n.right()
-                    .map(|v| v.interval() > n.interval())
-                    .unwrap_or(true)
-            );
+            assert!(n
+                .right()
+                .map(|v| v.interval() > n.interval())
+                .unwrap_or(true));
 
             // Invariant 3: the height of this node is always +1 of the
             // maximum child height.

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -897,4 +897,32 @@ mod tests {
         // Assert that the tree's reported max matches the computed max.
         assert_eq!(tree_max, nodes_max);
     }
+
+    /// The following test module ensures the pruning iterators yield references that can outlive
+    /// the query parameter. This test module must only compile to pass.
+    #[allow(dead_code)]
+    mod pruning_iter_lifetime {
+        use super::*;
+
+        macro_rules! compile_test {
+            ($fn:ident) => {
+                fn $fn<'a, R: Ord + Clone + Debug, V>(
+                    t: &'a IntervalTree<R, V>,
+                    range: Range<R>,
+                ) -> Vec<&'a V> {
+                    t.$fn(&range).map(|(_, x)| x).collect()
+                }
+            };
+        }
+
+        compile_test!(iter_overlaps);
+        compile_test!(iter_precedes);
+        compile_test!(iter_preceded_by);
+        compile_test!(iter_meets);
+        compile_test!(iter_met_by);
+        compile_test!(iter_starts);
+        compile_test!(iter_finishes);
+        compile_test!(iter_during);
+        compile_test!(iter_contains);
+    }
 }


### PR DESCRIPTION
This change allows the query to live shorter than the yielded elements. The change requires that the iterators returned share the query lifetime.

This fixes #16 