### PR TITLE
`rustfmt` config

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,2 @@
+#:schema https://www.schemastore.org/rustfmt.json
+# This empty config forces using default config instead of globally defined user's one.


### PR DESCRIPTION
Added `rustfmt`-config that forces to use default config instead of globally defined user's one.

~Also there has been set [`edition`s](https://github.com/rust-lang/rustfmt?tab=readme-ov-file#rusts-editions).~

_Examples from other projects: [gram][], [cargo][], [zed][],.._

[gram]: https://codeberg.org/GramEditor/gram/src/branch/main/.rustfmt.toml
[cargo]: https://github.com/rust-lang/cargo/blob/master/rustfmt.toml
[zed]: https://github.com/zed-industries/zed/blob/main/rustfmt.toml